### PR TITLE
wouldn't if(!myName) cover myName === null.

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -18,7 +18,7 @@ let myHeading = document.querySelector('h1');
 
 function setUserName() {
   let myName = prompt('Please enter your name.');
-  if(!myName || myName === null) {
+  if(!myName) {
     setUserName();
   } else {
     localStorage.setItem('name', myName);


### PR DESCRIPTION
I tested it in Google Chrome with only the first part of "if(!myName || myName === null)" and it works when I cancel the prompt and when I press Ok without entering anything.