### PR TITLE
docs(SECURITY): sync security policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@
 
 /.github/workflows/ @mdn/engineering
 /.github/CODEOWNERS @mdn/engineering
+/SECURITY.md @mdn/engineering

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,25 @@
 # Security Policy
 
+## Overview
+
+This policy applies to MDN's website (`developer.mozilla.org`), backend services, and GitHub repositories in the [`mdn`](https://github.com/mdn) organization. Issues affecting other Mozilla products or services should be reported through the [Mozilla Security Bug Bounty Program](https://www.mozilla.org/en-US/security/bug-bounty/).
+
+For non-security issues, please file a [content bug](https://github.com/mdn/content/issues/new/choose), a [website bug](https://github.com/mdn/fred/issues/new/choose) or a [content/feature suggestion](https://github.com/mdn/mdn/issues/new/choose).
+
 ## Reporting a Vulnerability
 
-If you've discovered a security issue, please report it through the form linked
-below, which will create a secure, private ticket.
-https://bugzilla.mozilla.org/form.web.bounty
+If you discover a potential security issue, please report it privately via <https://hackerone.com/mozilla>.
 
-MDN Web Docs may be eligible for
-[Mozilla's Security Bug Bounty Program](https://www.mozilla.org/en-US/security/bug-bounty/).
-You can find more information about the bounty program in the
-[Mozilla Web Bug Bounty FAQ](https://www.mozilla.org/en-US/security/bug-bounty/faq-webapp/).
-You can use the above form even if you are not interested in a bounty reward.
+If you prefer not to use HackerOne, you can report it via <https://bugzilla.mozilla.org/form.web.bounty>.
+
+## Bounty Program
+
+Vulnerabilities in MDN may qualify for Mozilla's Bug Bounty Program. Eligibility and reward amounts are described on <https://hackerone.com/mozilla>.
+
+Please use the above channels even if you are not interested in a bounty reward.
+
+## Responsible Disclosure
+
+Please do not publicly disclose details until Mozilla's security team and the MDN engineering team have verified and fixed the issue.
+
+We appreciate your efforts to keep MDN and its users safe.


### PR DESCRIPTION
### Description

Syncs the `SECURITY.md` file with the [canonical version from mdn/fred](https://github.com/mdn/fred/blob/main/SECURITY.md).

### Motivation

Ensures consistent security reporting procedures across all MDN repositories.

### Additional details

See: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1068.