### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,8 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # ----------------------------------------------------------------------------
 
+* @mdn/content-team
+
 /.github/workflows/ @mdn/engineering
 /.github/CODEOWNERS @mdn/engineering
 /SECURITY.md @mdn/engineering


### PR DESCRIPTION
### Description

This PR adds the content team as the fallback owner and also makes it consistent with CODEOWNERS in [beginner-html-site](https://github.com/mdn/beginner-html-site/blob/main/.github/CODEOWNERS) and [beginner-html-site-styled](https://github.com/mdn/beginner-html-site-styled/blob/main/.github/CODEOWNERS) repos.

### Motivation

Noticed the default missing


